### PR TITLE
fixing go version bump

### DIFF
--- a/default.json
+++ b/default.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:recommended"
   ],
+  "prConcurrentLimit": 1,
   "prCreation": "not-pending",
   "rebaseWhen": "behind-base-branch",
   "separateMajorMinor": false,
@@ -32,6 +33,17 @@
         "on the 1st and 15th day of the month"
       ],
       "minimumReleaseAge": "3"
+    },
+    {
+      "groupName": "Golang Version Bump",
+      "matchManagers": ["gomod"],
+      "matchDepNames": ["go"],
+      "matchDepTypes": ["golang"],
+      "rangeStrategy": "bump",
+      "postUpdateOptions": [
+        "gomodTidy",
+        "gomodUpdateImportPaths"
+      ],
     },
     {
       "groupName": "Dockerfile images",


### PR DESCRIPTION
This should automate the bumping of the go version in the go.mod file. The toolchain gets auto-updated but we have to manually add this rule to update the go version for go.mod

https://docs.renovatebot.com/modules/manager/gomod/#updating-of-go-mod-and-toolchain-directives

We also will limit the number of concurrent PRs to reduce PR spam, this is a best practice megabees have been doing and it makes it clearer which PR's need to get reviewed and merged first.